### PR TITLE
process.env.PORT error

### DIFF
--- a/appprueba.js
+++ b/appprueba.js
@@ -29,7 +29,7 @@ db.connect('mongodb://localhost:27017/unTestDB', function(err) {
     console.log('Unable to connect to Mongo.');
     process.exit(1);
   } else {
-    var server=app.listen(3000, function() {
+    var server=app.listen(process.env.PORT || 3000, function() {
       console.log('Listening in port %d', server.address().port);
     })
   }


### PR DESCRIPTION
En c9.io hay que usar process.env.PORT:

``` javascript
  var server=app.listen(3000, function() {
      console.log('Listening in port %d', server.address().port);
    })
```

``` javascript
  var server=app.listen(process.env.PORT || 3000, function() {
      console.log('Listening in port %d', server.address().port);
    })
```
